### PR TITLE
DOC: instructions on running the example with Queue Server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,3 +40,22 @@ Included custom functions:
 
 - **spreadsheet_to_plan_list"** for *.xlsx*, *.xlsm*, *.xltx* and *.xltm* files. Supports
 **data_type** = *wheel_xafs*.
+
+Running the Queue Server in the testing environment
+---------------------------------------------------
+
+Install *httpie* (*http* command): https://httpie.org/docs#installation
+
+The test will require 3 shells to be opened. In each shell set the current directory::
+
+  cd <path-to-the-repository-root>/bluesky_httpserver_bmm/tests/data
+
+Start Queue Server in shell #1::
+
+  start-re-manager --startup-dir ./simulated_startup_dir
+
+Start HTTP server in shell #2 as instructed above.
+
+Run the following command in shell #3 to upload the spreadsheet::
+
+  http --form POST http://localhost:60610/queue/upload/spreadsheet spreadsheet@sample_ss_wheel_xafs_1.xlsx data_type=wheel_xafs


### PR DESCRIPTION
Added instructions on running the example that illustrates uploading the BMM custom spreadsheet to Queue Server.